### PR TITLE
6th cell in table is narrower than the rest.

### DIFF
--- a/jquery.ui.datepicker.mobile.css
+++ b/jquery.ui.datepicker.mobile.css
@@ -19,7 +19,7 @@ div.hasDatepicker{ display: block; padding: 0; overflow: visible;  margin: 8px 0
 .ui-datepicker select.ui-datepicker-month-year {width: 100%;}
 .ui-datepicker select.ui-datepicker-month, 
 .ui-datepicker select.ui-datepicker-year { width: 49%;}
-.ui-datepicker table {width: 100%; border-collapse: collapse; margin:0; }
+.ui-datepicker table {width: 100%; border-collapse: collapse; margin:0; table-layout: fixed; }
 .ui-datepicker td { border-width: 1px; padding: 0; text-align: center; }
 .ui-datepicker td span, .ui-datepicker td a { display: block; padding: .2em 0; font-weight: bold; margin: 0; border-width: 0; text-align: center; text-decoration: none; }
 


### PR DESCRIPTION
Added a 'fixed' table-layout definition to '.ui-datepicker table' to correctly render the 6th cell in the calendar.
